### PR TITLE
feat(link): OG 메타 자동 수집 + --preview 옵션 추가

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Run tests
+        run: |
+          python run_tests.py -v
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Publish to PyPI
+        if: success()
+        uses: pypa/gh-action-pypi-publish@v1.12.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "breezy-til-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "📝 A CLI for managing your Today I Learned (TIL) notes"
+readme = "README.md"
 authors = [
     {name = "trinity", email = "trinity@dunamu.com"}
 ]
@@ -10,10 +11,27 @@ dependencies = [
     "pathspec",
 ]
 license = {text = "MIT License"}
+keywords = ["til", "cli", "notes", "productivity"]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Environment :: Console",
+  "Topic :: Utilities",
+]
 
 [project.scripts]
 til = "til.cli:main"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["til", "til.core"]
+include-package-data = true


### PR DESCRIPTION
요약\n- til link에 OG 메타 자동 수집(og:title, og:description, favicon) 추가\n- --preview 옵션으로 설명 1줄을 같은 줄에 병기(160자 제한)\n- 네트워크/파싱 실패 시 조용히 폴백, 24시간 캐시(.til_link_cache.json)\n- 기존 포맷 및 동작 유지, 전체 테스트 47개 통과\n\n변경 파일\n- til/core/metadata.py (신규)\n- til/core/link_manager.py (preview_text 지원)\n- til/cli.py (--preview 플래그 및 메타 수집 연동)\n- til/core/auto_git.py (stdout None 가드, 테스트 통과 보조)\n\n사용 예시\n- til link https://example.com\n- til link https://example.com --preview\n- til link https://example.com --title "내 제목" --tag kotlin\n\n참고\n- 제목 우선순위: og:title > <title> > URL\n- 설명 우선순위: og:description > meta[name=description]\n- favicon: <link rel*=icon> > /favicon.ico